### PR TITLE
refactor: require explicit encryption key

### DIFF
--- a/sitefb/README.md
+++ b/sitefb/README.md
@@ -23,6 +23,15 @@ Le script crée le fichier `backend/.env` avec les champs suivants:
 - CORS_ORIGINS
 - ENV
 
+### ENCRYPTION_KEY
+Clé Fernet en base64 (32 octets) utilisée pour chiffrer les tokens.
+Générez-en une avec:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+
 ## Migrations Alembic
 
 Au démarrage, `alembic upgrade head` est exécuté. Pour lancer manuellement:

--- a/sitefb/backend/app/auth.py
+++ b/sitefb/backend/app/auth.py
@@ -29,7 +29,7 @@ ENCRYPTION_KEY = os.getenv("ENCRYPTION_KEY")
 from cryptography.fernet import Fernet
 
 if not ENCRYPTION_KEY:
-    ENCRYPTION_KEY = base64.urlsafe_b64encode(os.urandom(32)).decode()
+    raise RuntimeError("ENCRYPTION_KEY environment variable is required")
 fernet = Fernet(ENCRYPTION_KEY.encode())
 
 def encrypt_token(token: str) -> str:

--- a/sitefb/scripts/setup.sh
+++ b/sitefb/scripts/setup.sh
@@ -9,6 +9,8 @@ if [ ! -f backend/.env ]; then
   read -p "DISCORD_CLIENT_SECRET: " DISCORD_CLIENT_SECRET
   read -p "DISCORD_BOT_TOKEN: " DISCORD_BOT_TOKEN
   read -p "JWT_SECRET: " JWT_SECRET
+  echo "ENCRYPTION_KEY doit être une clé Fernet (base64 de 32 octets)."
+  echo "Générez-en une avec: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'"
   read -p "ENCRYPTION_KEY: " ENCRYPTION_KEY
   read -p "FRONTEND_URL: " FRONTEND_URL
   read -p "REDIRECT_URI_DEV: " REDIRECT_URI_DEV


### PR DESCRIPTION
## Summary
- require ENCRYPTION_KEY environment variable for token encryption instead of generating a random value
- document ENCRYPTION_KEY usage and generation in README and setup script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba1b369718832ca3b92ab45d30a462