### PR TITLE
Improve tax computation and add tests

### DIFF
--- a/sitefb/backend/app/routers/tax.py
+++ b/sitefb/backend/app/routers/tax.py
@@ -53,18 +53,18 @@ async def set_tax(guild_id: int, cfg: TaxConfig, entreprise: Optional[str] = Non
 def compute_tax(amount: float, brackets: List[Dict[str, Any]], wealth: Optional[Dict[str, Any]] = None) -> float:
     tax = 0.0
     remaining = amount
-    last_max = 0.0
-    for b in sorted(brackets, key=lambda x: x.get('min', 0)):
-        bmin = float(b.get('min', 0))
-        bmax = b.get('max')
-        rate = float(b.get('rate', 0))
+    for b in sorted(brackets, key=lambda x: x.get("min", 0)):
         if remaining <= 0:
             break
-        if bmax is None:
-            base = max(0.0, amount - bmin)
-        else:
-            base = max(0.0, min(amount, float(bmax)) - bmin)
+        bmin = float(b.get("min", 0))
+        bmax = b.get("max")
+        rate = float(b.get("rate", 0))
+        if amount <= bmin:
+            break
+        upper = float(bmax) if bmax is not None else amount
+        base = min(remaining, max(0.0, upper - bmin))
         tax += base * rate
-    if wealth and amount > float(wealth.get('threshold', 0)):
-        tax += (amount - float(wealth['threshold'])) * float(wealth.get('rate', 0))
+        remaining -= base
+    if wealth and amount > float(wealth.get("threshold", 0)):
+        tax += (amount - float(wealth["threshold"])) * float(wealth.get("rate", 0))
     return round(tax, 2)

--- a/sitefb/backend/tests/test_tax.py
+++ b/sitefb/backend/tests/test_tax.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.routers.tax import compute_tax
+
+BRACKETS = [
+    {"min": 0, "max": 10000, "rate": 0.1},
+    {"min": 10000, "max": 20000, "rate": 0.2},
+    {"min": 20000, "rate": 0.3},
+]
+
+
+def test_compute_tax_multiple_brackets():
+    assert compute_tax(25000, BRACKETS) == 4500.0
+
+
+def test_compute_tax_partial_second_bracket():
+    assert compute_tax(15000, BRACKETS) == 2000.0
+
+
+def test_compute_tax_first_bracket_only():
+    assert compute_tax(5000, BRACKETS) == 500.0


### PR DESCRIPTION
## Summary
- fix tax calculation to decrement remaining base per bracket
- add regression tests covering multiple tax brackets

## Testing
- `cd sitefb/backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba1b4189e4832c9d44e1c9645224cb